### PR TITLE
rpm-build: remove --no-armor flag when sign to repos/debian/Releases

### DIFF
--- a/rpm-build/sign_to_deb.sh
+++ b/rpm-build/sign_to_deb.sh
@@ -13,4 +13,4 @@ if [ -n "$GPG_PASSPHRASE" -a -n "$GPG_FINGERPRINT" ]; then
     /usr/libexec/gpg-preset-passphrase --passphrase="$GPG_PASSPHRASE" --preset "$GPG_FINGERPRINT"
 fi
 
-gpg -s -b -a --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u "$GPG_NAME" --digest-algo SHA256 -o Release.gpg Release
+gpg -s -b -a --batch --no-verbose --use-agent --no-secmem-warning -u "$GPG_NAME" --digest-algo SHA256 -o Release.gpg Release


### PR DESCRIPTION
from: https://github.com/sacloud/usacloud/issues/515

aptリポジトリ内のReleasesファイルにGPGで署名する際に`--nor-armor`フラグが指定されているためにバイナリフォーマットでReleases.gpgが出力される。

このままだとDebian buster/testingでエラーとなるため`--no-armor`フラグ指定を外しASCII形式で出力するようにする。